### PR TITLE
chore: bump @shougo/ddc-vim to ~10.2.0

### DIFF
--- a/denops/@ddc-sources/filetype-candidates.ts
+++ b/denops/@ddc-sources/filetype-candidates.ts
@@ -1,6 +1,6 @@
 import type { Denops } from "jsr:@denops/std@~8.2.0";
-import { Item } from "jsr:@shougo/ddc-vim@~10.1.0/types";
-import { BaseSource } from "jsr:@shougo/ddc-vim@~10.1.0/source";
+import { Item } from "jsr:@shougo/ddc-vim@~10.2.0/types";
+import { BaseSource } from "jsr:@shougo/ddc-vim@~10.2.0/source";
 import { toFileUrl } from "jsr:@std/path@~1.1.0/to-file-url";
 import * as vars from "jsr:@denops/std@~8.2.0/variable";
 


### PR DESCRIPTION
#### :package: @shougo/ddc-vim ~10.1.0 → ~10.2.0